### PR TITLE
Remove redundant 'end' that prevents server.lua from running.

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -15,7 +15,6 @@ PerformHttpRequest("https://raw.githubusercontent.com/Flatracer/CoordsSaver_Reso
 	end
 	print("####################################################################")
 	print("\n")
-	end
 end)
 
 print('Write /savepos <Your_Comment> ingame to save the Coords, Heading and Comment in a ".txt" in the ' .. GetCurrentResourceName() .. ' - resource folder')


### PR DESCRIPTION
Removed a redundant 'end' that causes a critical parsing error resulting in the script not being loaded by the server.